### PR TITLE
BleedingEdge: Bump @salutejs/plasma-tokens-b2b from 1.36.0 to 1.37.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@prisma/client": "^5.11.0",
         "@salutejs/plasma-icons": "1.173.0",
         "@salutejs/plasma-tokens": "^1.55.0",
-        "@salutejs/plasma-tokens-b2b": "^1.36.0",
+        "@salutejs/plasma-tokens-b2b": "^1.37.0",
         "@salutejs/plasma-tokens-b2c": "^0.47.0",
         "@salutejs/plasma-tokens-web": "^1.51.0",
         "@salutejs/plasma-ui": "^1.242.0",
@@ -5496,9 +5496,9 @@
       }
     },
     "node_modules/@salutejs/plasma-tokens-b2b": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/plasma-tokens-b2b/-/plasma-tokens-b2b-1.36.0.tgz",
-      "integrity": "sha512-eZeiRmayTO/aLSdc0sX3qAcs2VTnePJXZgLl915mykBfMD1hGQ9G2m860lW7/kJjkfEeuuqSBwrfEEJ7HqeMXQ=="
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-tokens-b2b/-/plasma-tokens-b2b-1.37.0.tgz",
+      "integrity": "sha512-nKDCq03DmNda26ch+OMgltv74URt2b5HuJye9ajn89DYKDzvFMBs8BZ3ra6MsyQwzTiCtSAS28QvhR54exkgJw=="
     },
     "node_modules/@salutejs/plasma-tokens-b2c": {
       "version": "0.47.0",
@@ -5576,6 +5576,11 @@
         "react-dom": ">=16.13.1",
         "styled-components": "^5.1.1"
       }
+    },
+    "node_modules/@salutejs/plasma-web/node_modules/@salutejs/plasma-tokens-b2b": {
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-tokens-b2b/-/plasma-tokens-b2b-1.36.0.tgz",
+      "integrity": "sha512-eZeiRmayTO/aLSdc0sX3qAcs2VTnePJXZgLl915mykBfMD1hGQ9G2m860lW7/kJjkfEeuuqSBwrfEEJ7HqeMXQ=="
     },
     "node_modules/@salutejs/plasma-web/node_modules/@salutejs/plasma-tokens-b2c": {
       "version": "0.46.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@prisma/client": "^5.11.0",
     "@salutejs/plasma-icons": "1.173.0",
     "@salutejs/plasma-tokens": "^1.55.0",
-    "@salutejs/plasma-tokens-b2b": "^1.36.0",
+    "@salutejs/plasma-tokens-b2b": "^1.37.0",
     "@salutejs/plasma-tokens-b2c": "^0.47.0",
     "@salutejs/plasma-tokens-web": "^1.51.0",
     "@salutejs/plasma-ui": "^1.242.0",


### PR DESCRIPTION
Bumps @salutejs/plasma-tokens-b2b from 1.36.0 to 1.37.0.

---
updated-dependencies:
- dependency-name: "@salutejs/plasma-tokens-b2b" dependency-type: direct:production update-type: version-update:semver-minor ...